### PR TITLE
Initial proxy publishing support

### DIFF
--- a/README
+++ b/README
@@ -111,4 +111,5 @@ How do I use this thing ?
      mdnsctl browse -r http tcp
      # Publish a simple ftp service
      mdnsctl publish myftp ftp tcp 21 "user=foobar"
-     
+     # Proxy publish a https service that has www.mysite.com as the target
+     mdnsctl proxy mysite https tcp 443 www.mysite.com 12.3.45.6 "user=foobar"

--- a/mdnsctl/mdnsctl.8
+++ b/mdnsctl/mdnsctl.8
@@ -95,6 +95,25 @@ is the tcp or udp port.
 .Ar text-string
 is the string in the TXT record for the given service, it can be used to
 express additional service information.
+.It Xo
+.Cm proxy
+.Ar service-name
+.Ar application
+.Ar proto
+.Ar port
+.Ar host
+.Ar address
+.Ar text-string
+.Xc
+Proxy publish a service running on a different machine,
+in addition to the arguments used for
+.Sx \&publish ,
+.Ar host
+is a fully qualified domain name (FQDN) of the target machine,
+.Ar address
+is an IPv4 address for the target machine in the
+.Ar a.b.c.d
+form.
 .El
 .Sh FILES
 .Bl -tag -width "/var/run/mdnsctl.sockXX" -compact
@@ -124,6 +143,9 @@ mdnsctl browse -r http tcp
 
 # Publish a simple ftp service
 mdnsctl publish myftp ftp tcp 21 "user=foobar"
+
+# Proxy publish a https service that has www.mysite.com as the target
+mdnsctl proxy mysite https tcp 443 www.mysite.com 12.3.45.6 "user=foobar"
 .Ed
 .Sh SEE ALSO
 .Xr mdnsd 8

--- a/mdnsctl/mdnsctl.c
+++ b/mdnsctl/mdnsctl.c
@@ -112,7 +112,18 @@ main(int argc, char *argv[])
 		if (mdns_group_add(&mdns, res->srvname) == -1)
 			err(1, "mdns_group_add");
 		if (mdns_service_init(&ms, res->srvname, res->app, res->proto,
-		    res->port, res->txtstring, NULL) == -1)
+		    res->port, res->txtstring, NULL, NULL) == -1)
+			errx(1, "mdns_service_init");
+		if (mdns_group_add_service(&mdns, res->srvname, &ms) == -1)
+			errx(1, "mdns_group_add_service");
+		if (mdns_group_commit(&mdns, res->srvname) == -1)
+			errx(1, "mdns_group_commit");
+		break;
+	case PROXY:
+		if (mdns_group_add(&mdns, res->srvname) == -1)
+			err(1, "mdns_group_add");
+		if (mdns_service_init(&ms, res->srvname, res->app, res->proto,
+		    res->port, res->txtstring, res->hostname, &res->addr) == -1)
 			errx(1, "mdns_service_init");
 		if (mdns_group_add_service(&mdns, res->srvname, &ms) == -1)
 			errx(1, "mdns_group_add_service");

--- a/mdnsctl/mdnsl.c
+++ b/mdnsctl/mdnsl.c
@@ -293,7 +293,7 @@ mdns_group_commit(struct mdns *m, const char *group)
 
 int
 mdns_service_init(struct mdns_service *ms, const char *name, const char *app,
-    const char *proto, u_int16_t port, const char *txt, const char *hostname,
+    const char *proto, u_int16_t port, const char *txt, const char *target,
     struct in_addr *addr)
 {
 	bzero(ms, sizeof(*ms));
@@ -309,8 +309,8 @@ mdns_service_init(struct mdns_service *ms, const char *name, const char *app,
 	ms->port = port;
 	if (strlcpy(ms->txt, txt, sizeof(ms->txt)) >= sizeof(ms->txt))
 		return (-1);
-	if (hostname != NULL)
-		if (strlcpy(ms->target, hostname, sizeof(ms->target)) >= sizeof(ms->target))
+	if (target != NULL)
+		if (strlcpy(ms->target, target, sizeof(ms->target)) >= sizeof(ms->target))
 			return (-1);
 	if (addr != NULL)
 		ms->addr = *addr;

--- a/mdnsctl/mdnsl.c
+++ b/mdnsctl/mdnsl.c
@@ -294,7 +294,7 @@ mdns_group_commit(struct mdns *m, const char *group)
 int
 mdns_service_init(struct mdns_service *ms, const char *name, const char *app,
     const char *proto, u_int16_t port, const char *txt, const char *hostname,
-	struct in_addr *addr)
+    struct in_addr *addr)
 {
 	bzero(ms, sizeof(*ms));
 	

--- a/mdnsctl/mdnsl.c
+++ b/mdnsctl/mdnsl.c
@@ -293,7 +293,8 @@ mdns_group_commit(struct mdns *m, const char *group)
 
 int
 mdns_service_init(struct mdns_service *ms, const char *name, const char *app,
-    const char *proto, u_int16_t port, const char *txt, struct in_addr *addr)
+    const char *proto, u_int16_t port, const char *txt, const char *hostname,
+	struct in_addr *addr)
 {
 	bzero(ms, sizeof(*ms));
 	
@@ -308,6 +309,9 @@ mdns_service_init(struct mdns_service *ms, const char *name, const char *app,
 	ms->port = port;
 	if (strlcpy(ms->txt, txt, sizeof(ms->txt)) >= sizeof(ms->txt))
 		return (-1);
+	if (hostname != NULL)
+		if (strlcpy(ms->target, hostname, sizeof(ms->target)) >= sizeof(ms->target))
+			return (-1);
 	if (addr != NULL)
 		ms->addr = *addr;
 

--- a/mdnsctl/parser.c
+++ b/mdnsctl/parser.c
@@ -352,7 +352,7 @@ parse_hostname(const char *word, char hostname[MAXHOSTNAMELEN])
 	if (word == NULL || *word == '-')
 		return (0);
 	
-	if (strlen(word) < 7 ||	/* shorter host is a.local */
+	if (strlen(word) < 7 ||	/* shortest host is a.local */
 	    strcmp(&word[strlen(word) - 6], ".local") != 0) {
 		fprintf(stderr, "Invalid domain, must be .local\n");
 		return (0);

--- a/mdnsctl/parser.c
+++ b/mdnsctl/parser.c
@@ -153,7 +153,7 @@ static const struct token t_proxy_app_proto_port[] = {
 };
 
 static const struct token t_proxy_app_proto_port_target[] = {
-	{ FQDN,	"",		NONE,		t_proxy_app_proto_port_target_addr},
+	{ FQDN,		"",		NONE,		t_proxy_app_proto_port_target_addr},
 	{ ENDTOKEN,	"",		NONE,		t_proxy_app_proto_port_target_addr}
 };
 
@@ -164,7 +164,7 @@ static const struct token t_proxy_app_proto_port_target_addr[] = {
 
 static const struct token t_proxy_app_proto_port_target_addr_txt[] = {
 	{ TXTSTRING,	"",		PROXY,	NULL},
-	{ ENDTOKEN,	"",		NONE,		NULL}
+	{ ENDTOKEN,	"",		NONE,	NULL}
 };
 
 static struct parse_result	res;

--- a/mdnsctl/parser.h
+++ b/mdnsctl/parser.h
@@ -40,7 +40,8 @@ enum actions {
 	LOOKUP,
 	RLOOKUP,
 	BROWSE_PROTO,
-	PUBLISH
+	PUBLISH,
+	PROXY
 };
 
 struct parse_result {
@@ -60,6 +61,7 @@ const struct token	*match_token(const char *, const struct token *);
 void			 show_valid_args(const struct token *);
 int			 parse_addr(const char *, struct in_addr *);
 int			 parse_hostname(const char *, char [MAXHOSTNAMELEN]);
+int			 parse_target_hostname(const char *, char [MAXHOSTNAMELEN]);
 int			 parse_proto(const char *, char [MAXHOSTNAMELEN]);
 int			 parse_flags(const char *, int *);
 int			 parse_brflags(const char *, int *);

--- a/mdnsd/control.c
+++ b/mdnsd/control.c
@@ -373,8 +373,9 @@ control_group_add_service(struct ctl_conn *c, struct imsg *imsg)
 	memcpy(&msg, imsg->data, sizeof(msg));
 	msg.name[sizeof(msg.name) - 1] = '\0';
 	ms = &msg;
-	/* XXX deal with target, accept only ourselves for now */
-	(void)strlcpy(ms->target, conf->myname, sizeof(ms->target));
+	/* Default to ourself if target hostname not provided  */
+	if (strlen(ms->target) == 0)
+		(void)strlcpy(ms->target, conf->myname, sizeof(ms->target));
 
 	/* Group not found, or not newgroup commited */
 	pg = pg_get(0, ms->name, c);

--- a/mdnsd/mdns.h
+++ b/mdnsd/mdns.h
@@ -130,7 +130,7 @@ int	mdns_lookup_PTR(struct mdns *, const char *);
 int	mdns_lookup_HINFO(struct mdns *, const char *);
 int	mdns_lookup_rev(struct mdns *, struct in_addr *);
 int	mdns_service_init(struct mdns_service *, const char *, const char *,
-    const char *, u_int16_t, const char *, struct in_addr *);
+    const char *, u_int16_t, const char *, const char *, struct in_addr *);
 int	mdns_group_add(struct mdns *, const char *);
 int	mdns_group_reset(struct mdns *, const char *);
 int	mdns_group_add_service(struct mdns *, const char *, struct mdns_service *);

--- a/mdnsd/mdns.h
+++ b/mdnsd/mdns.h
@@ -22,6 +22,7 @@
 #ifndef _MDNS_H_
 #define	_MDNS_H_
 
+#include <sys/param.h>
 #include <sys/queue.h>
 #include <arpa/nameser.h>
 #include <netinet/in.h>


### PR DESCRIPTION
With the patch, it is now possible to proxy publish a service that has a unicast-DNS FQDN host as target, like so :
    mdnsctl proxy mysite https tcp 443 www.mysite.com 12.3.45.6 "user=foobar"

Know issues :
  .local proxy targets are not supported.
  'mdnsctl browse -r' doesn't want to resolve if unicast-DNS hostnames are involved.
