### PR TITLE
Add "script output" (-s) support to the browse command.

### DIFF
--- a/mdnsctl/mdnsctl.8
+++ b/mdnsctl/mdnsctl.8
@@ -13,7 +13,7 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd $Mdocdate: Feb 12 2011 $
+.Dd $Mdocdate: Apr 19 2016 $
 .Dt MDNSCTL 8
 .Os
 .Sh NAME
@@ -64,6 +64,7 @@ address.
 .It Xo
 .Cm browse
 .Op Fl r
+.Op Fl s
 .Op Ar application proto
 .Xc
 Browse for application services of type
@@ -137,6 +138,9 @@ mdnsctl browse
 
 # Browse and resolve all services
 mdnsctl browse -r
+
+# Browse and resolve all services and output in script-readable format
+mdnsctl browse -rs
 
 # Browse and resolve all the http services in the local network
 mdnsctl browse -r http tcp

--- a/mdnsctl/mdnsctl.c
+++ b/mdnsctl/mdnsctl.c
@@ -224,7 +224,10 @@ my_browse_hook(struct mdns *m, int ev, const char *name, const char *app,
 				err(1, "mdns_resolve");
 			return;
 		}
-		printf("+++ %-48s %-20s %-3s\n", name, app, proto);
+		if (res->flags & F_SCRIPT)
+			printf("proto|%s|app|%s|name|%s\n", proto, app, name);
+		else
+			printf("+++ %-48s %-20s %-3s\n", name, app, proto);
 		break;
 	case MDNS_SERVICE_DOWN:
 		if (name != NULL)
@@ -245,14 +248,20 @@ my_resolve_hook(struct mdns *m, int ev, struct mdns_service *ms)
 		fflush(stderr);
 		break;		/* NOTREACHED */
 	case MDNS_RESOLVE_SUCCESS:
-		printf("+++ %-48s %-20s %-3s\n", ms->name, ms->app, ms->proto);
-		printf(" Name: %s\n", ms->name);
-		/* printf(" Priority: %u\n", ms->priority); */
-		/* printf(" Weight: %u\n", ms->weight); */
-		printf(" Port: %u\n", ms->port);
-		printf(" Target: %s\n", ms->target);
-		printf(" Address: %s\n", inet_ntoa(ms->addr));
-		printf(" Txt: %s\n", ms->txt);
+		if (res->flags & F_SCRIPT) {
+			printf("proto|%s|app|%s|name|%s|port|%u|target|%s|address|%s|txt|%s\n",
+			    ms->proto, ms->app, ms->name, ms->port, ms->target,
+			    inet_ntoa(ms->addr), ms->txt);
+		} else {
+			printf("+++ %-48s %-20s %-3s\n", ms->name, ms->app, ms->proto);
+			printf(" Name: %s\n", ms->name);
+			/* printf(" Priority: %u\n", ms->priority); */
+			/* printf(" Weight: %u\n", ms->weight); */
+			printf(" Port: %u\n", ms->port);
+			printf(" Target: %s\n", ms->target);
+			printf(" Address: %s\n", inet_ntoa(ms->addr));
+			printf(" Txt: %s\n", ms->txt);
+		}
 		break;
 	default:
 		errx(1, "Unhandled event");

--- a/mdnsctl/mdnsctl.c
+++ b/mdnsctl/mdnsctl.c
@@ -225,13 +225,17 @@ my_browse_hook(struct mdns *m, int ev, const char *name, const char *app,
 			return;
 		}
 		if (res->flags & F_SCRIPT)
-			printf("proto|%s|app|%s|name|%s\n", proto, app, name);
+			printf("up|proto|%s|app|%s|name|%s\n", proto, app, name);
 		else
 			printf("+++ %-48s %-20s %-3s\n", name, app, proto);
 		break;
 	case MDNS_SERVICE_DOWN:
-		if (name != NULL)
-			printf("--- %-48s %-20s %-3s\n", name, app, proto);
+		if (name != NULL) {
+			if (res->flags & F_SCRIPT)
+				printf("down|proto|%s|app|%s|name|%s\n", proto, app, name);
+			else
+				printf("--- %-48s %-20s %-3s\n", name, app, proto);
+		}
 		break;
 	default:
 		errx(1, "Unhandled event");
@@ -249,7 +253,7 @@ my_resolve_hook(struct mdns *m, int ev, struct mdns_service *ms)
 		break;		/* NOTREACHED */
 	case MDNS_RESOLVE_SUCCESS:
 		if (res->flags & F_SCRIPT) {
-			printf("proto|%s|app|%s|name|%s|port|%u|target|%s|address|%s|txt|%s\n",
+			printf("up|proto|%s|app|%s|name|%s|port|%u|target|%s|address|%s|txt|%s\n",
 			    ms->proto, ms->app, ms->name, ms->port, ms->target,
 			    inet_ntoa(ms->addr), ms->txt);
 		} else {

--- a/mdnsctl/parser.c
+++ b/mdnsctl/parser.c
@@ -483,6 +483,10 @@ parse_brflags(const char *word, int *flags)
 			*flags |= F_RESOLV;
 			r++;
 			break;
+		case 's':
+			*flags |= F_SCRIPT;
+			r++;
+			break;
 		default:
 			errx(1, "unknown flag -%c", *word);
 		}

--- a/mdnsctl/parser.h
+++ b/mdnsctl/parser.h
@@ -34,6 +34,7 @@
 
 /* BRFLAGS */
 #define F_RESOLV	1
+#define	F_SCRIPT	2
 
 enum actions {
 	NONE,


### PR DESCRIPTION
A new `-s` flag makes the output easier to handle for scripts by using a pipe-separated single line format. Even index is field name, odd index is field value. General format:

```
proto|<proto>|app|<app>|name|<name>|port|<port>|target|<target>|address|<address>|txt|<txt>
```

Example:

```
proto|tcp|app|ssh|name|mbp|port|22|target|mbp.local|address|10.0.0.11|txt|
```

Parsing:

```
$ python
Python 2.7.11 (default, Feb 14 2016, 18:09:08) 
[GCC 4.2.1 20070719 ] on openbsd5
Type "help", "copyright", "credits" or "license" for more information.
>>> s = 'proto|tcp|app|ssh|name|mbp|port|22|target|mbp.local|address|10.0.0.11|txt|';
>>> s = s.split('|')
>>> d = dict(zip(s[0::2], s[1::2]))
>>> print(d)
{'target': 'mbp.local', 'proto': 'tcp', 'app': 'ssh', 'address': '10.0.0.11', 'txt': '', 'port': '22', 'name': 'mbp'}
>>> 
```