### PR TITLE
mdnshosts experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Introduction
+
+This extends Christiano Haesbaert's [openmdns](https://github.com/haesbaert/mdnsd) suite of tools
+with a new daemon, *mdnshosts*.
+It listens to the local [mdnsd(8)](http://www.haesbaert.org/openmdns/mdnsd.8.html) and maintains the
+system's */etc/hosts* based upon what it finds.
+
+The original */etc/hosts* is safely backed up and restored on exit---don't worry.
+
+I'll post more information here as I develop the tool.

--- a/mdnsctl/mdnsctl.c
+++ b/mdnsctl/mdnsctl.c
@@ -67,12 +67,18 @@ main(int argc, char *argv[])
 	struct mdns		mdns;
 	struct mdns_service	ms;
 
+	if (-1 == pledge("stdio unix", NULL))
+		err(EXIT_FAILURE, NULL);
+
 	/* parse options */
 	if ((res = parse(argc - 1, argv + 1)) == NULL)
 		exit(1);
 
 	if ((sockfd = mdns_open(&mdns)) == -1)
 		err(1, "mdns_open");
+
+	if (-1 == pledge("stdio", NULL))
+		err(EXIT_FAILURE, NULL);
 
 	mdns_set_lookup_A_hook(&mdns, my_lookup_A_hook);
 	mdns_set_lookup_PTR_hook(&mdns, my_lookup_PTR_hook);

--- a/mdnsctl/mdnsctl.c
+++ b/mdnsctl/mdnsctl.c
@@ -67,18 +67,12 @@ main(int argc, char *argv[])
 	struct mdns		mdns;
 	struct mdns_service	ms;
 
-	if (-1 == pledge("stdio unix", NULL))
-		err(EXIT_FAILURE, NULL);
-
 	/* parse options */
 	if ((res = parse(argc - 1, argv + 1)) == NULL)
 		exit(1);
 
 	if ((sockfd = mdns_open(&mdns)) == -1)
 		err(1, "mdns_open");
-
-	if (-1 == pledge("stdio", NULL))
-		err(EXIT_FAILURE, NULL);
 
 	mdns_set_lookup_A_hook(&mdns, my_lookup_A_hook);
 	mdns_set_lookup_PTR_hook(&mdns, my_lookup_PTR_hook);

--- a/mdnshosts/Makefile
+++ b/mdnshosts/Makefile
@@ -1,0 +1,18 @@
+PREFIX?=/usr/local
+BINDIR=${PREFIX}/bin
+
+PROG=	mdnshosts
+SRCS=	main.c mdnsl.c 
+
+CFLAGS+= -g -Wall
+CFLAGS+= -Wstrict-prototypes -Wmissing-prototypes
+CFLAGS+= -Wmissing-declarations
+CFLAGS+= -Wshadow -Wpointer-arith -Wcast-qual
+CFLAGS+= -Wsign-compare
+CFLAGS+= -I${.CURDIR} -I${.CURDIR}/../mdnsd
+LDADD+= -lutil
+DPADD+=  ${LIBUTIL}
+
+MAN=	${PROG}.8
+
+.include <bsd.prog.mk>

--- a/mdnshosts/main.c
+++ b/mdnshosts/main.c
@@ -1,0 +1,684 @@
+/*
+ * Copyright (c) 2017 Kristaps Dzonsons <kristaps@bsd.lv>
+ * Copyright (c) 2010,2011 Christiano F. Haesbaert <haesbaert@haesbaert.org>
+ * Copyright (c) 2006 Michele Marchetto <mydecay@openbeer.it>
+ * Copyright (c) 2005 Claudio Jeker <claudio@openbsd.org>
+ * Copyright (c) 2004, 2005 Esben Norby <norby@openbsd.org>
+ * Copyright (c) 2003 Henning Brauer <henning@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <sys/queue.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <net/if_media.h>
+#include <net/if_types.h>
+
+#include <err.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <imsg.h>
+
+#include "mdns.h"
+
+/*
+ * A named host entry reported by the mdns server.
+ * This is unique over "name" entries.
+ */
+struct	hostent {
+	char		*name; /* unique name */
+	struct in_addr	 addr; 
+	char		*target;
+	size_t		 refs;
+};
+
+struct	hostdb {
+	struct hostent	*hosts;
+	size_t		 hostsz;
+};
+
+static	int	writer;
+
+/*
+ * Look up entry named "name" in our database of entries.
+ * TODO: use ohash or another hash based lookup.
+ * Returns the entry or NULL if it doesn't exist.
+ */
+static struct hostent *
+db_lookup(struct hostdb *db, const char *name)
+{
+	size_t	 i;
+
+	for (i = 0; i < db->hostsz; i++)
+		if (0 == strcmp(name, db->hosts[i].name))
+			return(&db->hosts[i]);
+
+	return(NULL);
+}
+
+/*
+ * Decrement a reference counter, if active.
+ */
+static void
+db_unref(struct hostent *ent)
+{
+
+	if (ent->refs) 
+		warnx("writer: entry down: %s (%zu refs)", 
+			ent->name, --ent->refs);
+	else
+		warnx("writer: entry down: %s (already down)", 
+			ent->name);
+}
+
+/*
+ * Increase the reference count of a name.
+ * This always frees the "target" pointer.
+ * Also check whether our IP address and/or target is changing.
+ */
+static void
+db_ref(struct hostent *ent, char *target, const struct in_addr *addr)
+{
+	char	 buf[64];
+	char	*cp;
+
+	if (ent->refs) {
+		warnx("writer: known entity being referenced: "
+			"%s (%zu refs)", ent->name, ent->refs + 1);
+		cp = inet_ntoa(*addr);
+		strlcpy(buf, cp, sizeof(buf));
+		if (memcmp(&ent->addr, addr, sizeof(ent->addr))) {
+			warnx("address changed: is %s, was %s: %s", 
+				buf, inet_ntoa(ent->addr), ent->name);
+			memcpy(&ent->addr, addr, sizeof(ent->addr));
+		}
+		if (strcmp(ent->target, target)) {
+			warnx("target changed: is %s, was %s: %s", 
+				ent->target, target, ent->name);
+			free(ent->target);
+			ent->target = target;
+			target = NULL;
+		} 
+	} else {
+		warnx("writer: known entity "
+			"coming online: %s", ent->name);
+		memcpy(&ent->addr, addr, sizeof(ent->addr));
+		free(ent->target);
+		ent->target = target;
+		target = NULL;
+	}
+
+	ent->refs++;
+	free(target);
+}
+
+/*
+ * Add an entry to the database.
+ * IT MUST NOT ALREADY EXIST.
+ * Initialises the entry with the given attributes.
+ */
+static void
+db_add(struct hostdb *db, char *name, 
+	char *target, struct in_addr *addr)
+{
+
+	db->hosts = reallocarray(db->hosts, 
+		db->hostsz + 1, sizeof(struct hostent));
+	if (NULL == db->hosts)
+		err(EXIT_FAILURE, NULL);
+
+	db->hosts[db->hostsz].refs = 1;
+	db->hosts[db->hostsz].target = target;
+	db->hosts[db->hostsz].name = name;
+	memcpy(&db->hosts[db->hostsz].addr, 
+		addr, sizeof(struct in_addr));
+	db->hostsz++;
+	warnx("writer: unknown entity coming online: %s "
+		"(%s -> %s)", name, inet_ntoa(*addr), target);
+}
+
+/*
+ * Write binary buffer "buf" of size "sz" to the descriptor.
+ * Return zero on failure, non-zero on success.
+ */
+static int
+write_buf(int fd, const char *name, const void *buf, size_t sz)
+{
+	ssize_t	 ssz;
+
+	ssz = write(fd, buf, sz);
+	if (ssz < 0) {
+		warn("write: %s", name);
+		return(-1);
+	} else if (sz != (size_t)ssz) {
+		warnx("short write: %s", name);
+		return(-1);
+	}
+
+	return(1);
+}
+
+/*
+ * Write nil-terminated string "buf" to the descriptor.
+ * Return zero on failure, non-zero on success.
+ */
+static int
+write_str(int fd, const char *name, const char *buf)
+{
+	size_t	 sz;
+
+	sz = strlen(buf) + 1;
+	if (write_buf(fd, name, &sz, sizeof(size_t)) < 0)
+		return(0);
+	return(write_buf(fd, name, buf, sz));
+}
+
+/*
+ * Write an integral token to the descriptor.
+ * Return zero on failure, non-zero on success.
+ */
+static int
+write_token(int fd, const char *name, int token)
+{
+
+	return(write_buf(fd, name, &token, sizeof(int)));
+}
+
+/*
+ * Read a buffer "buf" of known size "sz".
+ * Returns zero on failure, non-zero on success.
+ */
+static int
+read_buf(int fd, const char *name, void *buf, size_t sz)
+{
+	ssize_t	 ssz;
+
+	if ((ssz = read(fd, buf, sz)) < 0) {
+		warn("read: %s", name);
+		return(0);
+	} else if (sz != (size_t)ssz) {
+		warnx("short read: %s", name);
+		return(0);
+	}
+
+	return(1);
+}
+
+/* 
+ * Read a string into "buf".
+ * Returns zero on failure, non-zero on success.
+ */
+static int
+read_str(int fd, const char *name, char **buf)
+{
+	ssize_t	 ssz;
+	size_t	 sz;
+
+	ssz = read(fd, &sz, sizeof(size_t));
+	if (ssz < 0) {
+		warn("read: %s", name);
+		return(0);
+	} else if (sizeof(size_t) != (size_t)ssz) {
+		warnx("short read: %s", name);
+		return(0);
+	}
+
+	if (NULL == (*buf = malloc(sz)))
+		err(EXIT_FAILURE, NULL);
+
+	ssz = read(fd, *buf, sz);
+	if (ssz < 0) {
+		warn("read: %s", name);
+		return(0);
+	} else if (sz != (size_t)ssz) {
+		warnx("short read: %s", name);
+		return(0);
+	}
+
+	return(1);
+}
+
+/*
+ * Read an integral token into "tok", if non-NULL.
+ * Returns <0 on failure, 0 on disconnect, >0 on success.
+ */
+static int
+read_token(int fd, const char *name, int *tok)
+{
+	ssize_t	 ssz;
+	int	 code = 1;
+
+	if (NULL == tok)
+		tok = &code;
+
+	ssz = read(fd, tok, sizeof(int));
+	if (ssz < 0) {
+		warn("read: %s", name);
+		return(-1);
+	} else if (0 == ssz) {
+		return(0);
+	} else if (sizeof(int) != (size_t)ssz) {
+		warnx("short read: %s", name);
+		return(-1);
+	}
+
+	return(1);
+}
+
+/*
+ * A browsing event has occurred: entity down or up.
+ * If down, pass it to the writer.
+ * If up, resolve address and pass to hosts_resolv_hook().
+ */
+static void
+hosts_browse_hook(struct mdns *m, int ev, 
+	const char *name, const char *app, const char *proto)
+{
+
+	switch (ev) {
+	case MDNS_SERVICE_UP:
+		break;
+	case MDNS_SERVICE_DOWN:
+		if (name == NULL)
+			return;
+		if ( ! write_token(writer, "service down", 1))
+			errx(EXIT_FAILURE, "write_token");
+		if ( ! write_str(writer, "name", name))
+			errx(EXIT_FAILURE, "write_str");
+		return;
+	default:
+		errx(EXIT_FAILURE, "unhandled browse event");
+		/* NOTREACHED */
+	}
+
+	if (name == NULL) {
+		if (mdns_browse_add(m, app, proto) == -1)
+			errx(EXIT_FAILURE, "mdns_browse_add");
+	} else {
+		if (mdns_resolve(m, name, app, proto) == -1)
+			errx(EXIT_FAILURE, "mdns_resolve");
+	}
+}
+
+/*
+ * Address has been resolved.
+ * Pass to the writer (entity up).
+ */
+static void
+hosts_resolv_hook(struct mdns *m, int ev, struct mdns_service *ms)
+{
+
+	switch (ev) {
+	case MDNS_RESOLVE_FAILURE:
+		warnx("can't resolve: %s", ms->name);
+		return;
+	case MDNS_RESOLVE_SUCCESS:
+		break;
+	default:
+		errx(EXIT_FAILURE, "unhandled resolve event");
+		/* NOTREACHED */
+	}
+
+	if ( ! write_token(writer, "service up", 2))
+		errx(EXIT_FAILURE, "write_token");
+	if ( ! write_str(writer, "name", ms->name))
+		errx(EXIT_FAILURE, "write_str");
+	if ( ! write_buf(writer, "addr", &ms->addr, sizeof(ms->addr)))
+		errx(EXIT_FAILURE, "write_buf");
+	if ( ! write_str(writer, "target", ms->target))
+		errx(EXIT_FAILURE, "write_str");
+}
+
+static int
+proc_writer(int wfd, int rfd)
+{
+	int	 	 c, rc = 0, tok, change;
+	struct hostdb	 db;
+	size_t		 i;
+	FILE		*f;
+	char		*name = NULL, *target = NULL;
+	struct hostent	*ent;
+	struct in_addr	 addr;
+
+	memset(&db, 0, sizeof(struct hostdb));
+
+	/* Make us safe: trap us in /etc/mdns. */
+
+	if (-1 == chroot("/etc/mdns")) {
+		warn("chroot");
+		return(0);
+	} else if (-1 == chdir("/")) {
+		warnx("chdir");
+		return(0);
+	} else if (-1 == pledge("stdio cpath wpath fattr rpath", NULL)) {
+		warn("pledge");
+		return(0);
+	}
+
+	/* Wait until the renamer has started up. */
+
+	if (0 == (c = read_token(wfd, "renamer up", NULL))) {
+		warnx("process down: renamer");
+		return(0);
+	} else if (-1 == c)
+		return(0);
+
+	/*
+	 * Main loop: wait until we receive an update on our hosts, then
+	 * flush any changes to the file hosts.
+	 * Re-create this every time.
+	 */
+
+	for (;;) {
+		if (0 == (c = read_token(rfd, "update", &tok))) {
+			warnx("writer: updater has exited");
+			rc = 1;
+			break;
+		} else if (c < 0)
+			break;
+
+		change = 0;
+
+		/* Process addition or deletion. */
+
+		if (1 == tok) {
+			if ( ! read_str(rfd, "name", &name))
+				break;
+
+			if (NULL != (ent = db_lookup(&db, name))) {
+				change = 1 == ent->refs;
+				db_unref(ent);
+			} else
+				warnx("unknown service: %s", name);
+
+			free(name);
+			name = NULL;
+		} else if (2 == tok) {
+			if ( ! read_str(rfd, "name", &name))
+				break;
+			if ( ! read_buf(rfd, "addr", &addr, sizeof(addr)))
+				break;
+			if ( ! read_str(rfd, "target", &target))
+				break;
+
+			if (NULL != (ent = db_lookup(&db, name))) {
+				free(name);
+				change = 0 == ent->refs;
+				db_ref(ent, target, &addr);
+			} else {
+				change = 1;
+				db_add(&db, name, target, &addr);
+			}
+			name = target = NULL;
+		} else 
+			err(EXIT_FAILURE, "unknown token");
+
+		if ( ! change)
+			continue;
+
+		if (NULL == (f = fopen("hosts", "a"))) {
+			warn("/etc/mdns/hosts");
+			break;
+		}
+
+		fprintf(f, "127.0.0.1 localhost\n");
+		fprintf(f, "::1 localhost\n");
+		for (i = 0; i < db.hostsz; i++) {
+			fprintf(f, "%s %s\n", 
+				inet_ntoa(db.hosts[i].addr), 
+				db.hosts[i].target);
+		}
+		fclose(f);
+
+		if (-1 == chmod("hosts", 0644)) {
+			warn("/etc/mdns/hosts");
+			break;
+		}
+
+		warnx("writer: created /etc/mdns/hosts");
+		if ( ! write_token(wfd, "writer req", 1))
+			break;
+		if ( ! read_token(wfd, "writer resp", NULL))
+			break;
+		warnx("writer: changes flushed");
+	}
+
+	free(target);
+	free(name);
+
+	for (i = 0; i < db.hostsz; i++) {
+		free(db.hosts[i].name);
+		free(db.hosts[i].target);
+	}
+
+	free(db.hosts);
+	return(rc);
+}
+
+static int
+proc_renamer(int fd)
+{
+	int	 c, rc = 0;
+
+	warnx("renamer: start");
+
+	/* 
+	 * Make us safe: chroot in /etc and pledge.
+	 * We need to use rename(2) (and thus cpath) in this because
+	 * /etc/hosts needs to have sane contents at all times.
+	 */
+
+	if (-1 == chroot("/etc")) {
+		warn("chroot");
+		return(0);
+	} else if (-1 == chdir("/")) {
+		warnx("chdir");
+		return(0);
+	} else if (-1 == pledge("stdio rpath cpath", NULL)) {
+		warn("pledge");
+		return(0);
+	}
+
+	warnx("renamer: /etc/hosts <-> /etc/hosts/mdns.save");
+
+	/* Back up our current /etc/hosts. */
+
+	if (-1 == link("hosts", "hosts.mdns.save")) {
+		warn("link: /etc/hosts, /etc/hosts.mdns.save");
+		return(0);
+	}
+
+	warnx("renamer: notifying reader");
+
+	/* Notify the writer that we're ready. */
+
+	if ( ! write_token(fd, "reader up", 1))
+		return(0);
+
+	/*
+	 * Read loop.
+	 * When our writer notifies us, we rename the hard-link.
+	 * That's all.
+	 */
+
+	warnx("renamer: main loop");
+
+	for (;;) {
+		if (0 == (c = read_token(fd, "writer req", NULL))) {
+			warnx("renamer: writer has exited");
+			rc = 1;
+			break;
+		} else if (c < 0)
+			break;
+
+		warnx("renamer: /etc/mdns/hosts -> /etc/hosts");
+
+		/*
+		 * The /etc/mdns/hosts file is created and managed by
+		 * another process.
+		 * While we're in this section, this other process will
+		 * not touch the file.
+		 * It will then re-create it when more updates are
+		 * necessary, leaving the inode secure.
+		 */
+
+		if (-1 == rename("mdns/hosts", "hosts")) {
+			warn("rename: /etc/mdns/hosts, /etc/hosts");
+			break;
+		}
+
+		if ( ! write_token(fd, "writer resp", 1))
+			break;
+	}
+
+	/* Recovery: replace our /etc/hosts with the original. */
+
+	warnx("renamer: /etc/hosts.mdns.save -> /etc/hosts");
+
+	if (-1 == rename("hosts.mdns.save", "hosts")) {
+		warn("rename: /etc/hosts.mdns.save, /etc/hosts");
+		return(0);
+	}
+
+	warnx("renamer: /etc/hosts/mdns.save -> (remove)");
+	remove("hosts.mdns.save");
+	return(rc);
+}
+
+static	volatile sig_atomic_t doexit = 0;
+
+static void
+dosig(int code)
+{
+
+	doexit = 1;
+}
+
+int
+main(int argc, char *argv[])
+{
+	int		 c, sockfd;
+	int		 hsock[2], wsock[2];
+	struct mdns	 mdns;
+	ssize_t		 n;
+	pid_t		 hpid, wpid;
+
+	/*
+	 * Create the renamer, which just sits there til it's woken, at
+	 * which point it renames /etc/mdns/hosts as /etc/hosts.
+	 */
+
+	signal(SIGINT, SIG_IGN);
+	signal(SIGHUP, SIG_IGN);
+	signal(SIGCHLD, dosig);
+
+	if (-1 == socketpair(AF_UNIX, SOCK_STREAM, 0, hsock))
+		err(EXIT_FAILURE, "socketpair");
+	if (-1 == socketpair(AF_UNIX, SOCK_STREAM, 0, wsock))
+		err(EXIT_FAILURE, "socketpair");
+
+	warnx("starting renamer");
+
+	if (-1 == (hpid = fork()))
+		err(EXIT_FAILURE, "fork");
+
+	if (0 == hpid) {
+		close(hsock[0]);
+		close(wsock[0]);
+		close(wsock[1]);
+		c = proc_renamer(hsock[1]);
+		close(hsock[1]);
+		_exit(c ? EXIT_SUCCESS : EXIT_FAILURE);
+	}
+
+	close(hsock[1]);
+
+	warnx("starting writer");
+
+	/*
+	 * Create the writer.
+	 * This keeps track of which hosts are up and down, and
+	 * serialies these changes to a file.
+	 * When it updates the file, it notifies the renamer.
+	 */
+
+	if (-1 == (wpid = fork()))
+		err(EXIT_FAILURE, "fork");
+
+	if (0 == wpid) {
+		close(wsock[0]);
+		c = proc_writer(hsock[0], wsock[1]);
+		close(wsock[1]);
+		close(hsock[1]);
+		_exit(c ? EXIT_SUCCESS : EXIT_FAILURE);
+	}
+
+	close(hsock[0]);
+	close(wsock[1]);
+
+	writer = wsock[0];
+
+	warnx("updater: starting");
+
+	signal(SIGINT, dosig);
+
+	/*
+	 * Now we just have a communicator to the writer in wsock[0].
+	 * That's all we need.
+	 * We'll use it to pass host updates.
+	 */
+
+	if (-1 == chroot("/var/empty"))
+		err(EXIT_FAILURE, "/var/empty");
+	else if (-1 == chdir("/")) 
+		err(EXIT_FAILURE, "/var/empty");
+	else if (-1 == pledge("stdio unix", NULL))
+		err(EXIT_FAILURE, NULL);
+
+	if (-1 == (sockfd = mdns_open(&mdns)))
+		err(EXIT_FAILURE, "mdns_open");
+
+	if (-1 == pledge("stdio", NULL))
+		err(EXIT_FAILURE, NULL);
+
+	mdns_set_browse_hook(&mdns, hosts_browse_hook);
+	mdns_set_resolve_hook(&mdns, hosts_resolv_hook);
+
+	if (-1 == mdns_browse_add(&mdns, NULL, NULL))
+		err(EXIT_FAILURE, "mdns_browse_add");
+
+	warnx("updater: browse loop");
+
+	while ( ! doexit) 
+		if (-1 == (n = mdns_read(&mdns)))
+			errx(EXIT_FAILURE, "mdns_read");
+		else if (n == 0)
+			errx(EXIT_FAILURE, "server closed socket");
+
+	warnx("updater: exiting");
+
+	mdns_close(&mdns);
+
+	close(writer);
+	close(sockfd);
+
+	return(EXIT_SUCCESS);
+}

--- a/mdnshosts/mdnshosts.8
+++ b/mdnshosts/mdnshosts.8
@@ -1,0 +1,50 @@
+.\"	$OpenBSD: mdoc.template,v 1.15 2014/03/31 00:09:54 dlg Exp $
+.\"
+.\" Copyright (c) 2017 Kristaps Dzonsons <kristaps@bsd.lv>
+.\"
+.\" Permission to use, copy, modify, and distribute this software for any
+.\" purpose with or without fee is hereby granted, provided that the above
+.\" copyright notice and this permission notice appear in all copies.
+.\"
+.\" THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+.\" WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+.\" MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+.\" ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+.\" WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+.\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+.\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+.\"
+.Dd $Mdocdate$
+.Dt MDNSHOSTS 8
+.Os
+.Sh NAME
+.Nm mdnshosts
+.Nd update /etc/hosts with mdns network information
+.Sh SYNOPSIS
+.Nm mdnshosts
+.Sh DESCRIPTION
+The
+.Nm
+utility connects to the running
+.Xr mdnsd 8
+and manages
+.Pa /etc/hosts
+with local network hosts.
+.Pp
+On startup,
+.Pa /etc/hosts
+is linked to
+.Pa /etc/hosts.mdns.save .
+This file is restored on exit.
+.\" .Sh FILES
+.Sh EXIT STATUS
+.Ex -std
+.\" .Sh DIAGNOSTICS
+.Sh SEE ALSO
+.Xr hosts 5 ,
+.Xr mdnsd 8
+.\" .Sh STANDARDS
+.\" .Sh HISTORY
+.\" .Sh AUTHORS
+.\" .Sh CAVEATS
+.\" .Sh BUGS

--- a/mdnshosts/mdnsl.c
+++ b/mdnshosts/mdnsl.c
@@ -1,0 +1,619 @@
+/*
+ * Copyright (c) 2010 Christiano F. Haesbaert <haesbaert@haesbaert.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/socket.h>
+#include <sys/queue.h>
+#include <sys/un.h>
+#include <netinet/in.h>
+
+#include <arpa/inet.h>
+
+#include <fcntl.h>
+#include <errno.h>
+#include <err.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <imsg.h>
+
+#include "../mdnsd/mdnsd.h"
+#include "mdns.h"
+
+static int	mdns_connect(void);
+static int 	mdns_lookup_do(struct mdns *, const char [MAXHOSTNAMELEN],
+    u_int16_t, u_int16_t);
+static int	ibuf_send_imsg(struct imsgbuf *, u_int32_t,
+    void *, u_int16_t);
+static int	splitdname(char [MAXHOSTNAMELEN], char [MAXHOSTNAMELEN],
+    char [MAXLABEL], char [4], int *);
+static int	imsgctl_to_event(int);
+
+static int mdns_browse_adddel(struct mdns *, const char *, const char *, u_int);
+static int mdns_handle_lookup(struct mdns *, struct rr *, int);
+static int mdns_handle_browse(struct mdns *, struct rr *, int);
+static int mdns_handle_resolve(struct mdns *, struct mdns_service *, int);
+static int mdns_handle_group(struct mdns *, char [MAXHOSTNAMELEN], int);
+
+int
+mdns_open(struct mdns *m)
+{
+	int sockfd;
+	
+	bzero(m, sizeof(*m));
+	if ((sockfd = mdns_connect()) == -1)
+		return (-1);
+	imsg_init(&m->ibuf, sockfd);
+	
+	return (sockfd);
+}
+
+void
+mdns_close(struct mdns *m)
+{
+	imsg_clear(&m->ibuf);
+}
+
+void
+mdns_set_lookup_A_hook(struct mdns *m, lookup_A_hook lhk)
+{
+	m->lhk_A = lhk;
+}
+
+void
+mdns_set_lookup_PTR_hook(struct mdns *m, lookup_PTR_hook lhk)
+{
+	m->lhk_PTR = lhk;
+}
+
+void
+mdns_set_lookup_HINFO_hook(struct mdns *m, lookup_HINFO_hook hhk)
+{
+	m->lhk_HINFO = hhk;
+}
+
+void
+mdns_set_browse_hook(struct mdns *m, browse_hook bhk)
+{
+	m->bhk = bhk;
+}
+
+void
+mdns_set_resolve_hook(struct mdns *m, resolve_hook rhk)
+{
+	m->rhk = rhk;
+}
+
+void
+mdns_set_udata(struct mdns *m, void *udata)
+{
+	m->udata = udata;
+}
+
+void
+mdns_set_group_hook(struct mdns *m, group_hook ghk)
+{
+	m->ghk = ghk;
+}
+
+int
+mdns_lookup_A(struct mdns *m, const char *host)
+{
+	return (mdns_lookup_do(m, host, T_A, C_IN));
+}
+
+int
+mdns_lookup_PTR(struct mdns *m, const char *ptr)
+{
+	return (mdns_lookup_do(m, ptr, T_PTR, C_IN));
+}
+
+int
+mdns_lookup_rev(struct mdns *m, struct in_addr *addr)
+{
+	char	name[MAXHOSTNAMELEN];
+
+	reversstr(name, addr);
+	name[sizeof(name) - 1] = '\0';
+	
+	return (mdns_lookup_PTR(m, name));
+}
+
+int
+mdns_lookup_HINFO(struct mdns *m, const char *host)
+{
+	return (mdns_lookup_do(m, host, T_HINFO, C_IN));
+}
+
+static int
+mdns_lookup_do(struct mdns *m, const char name[MAXHOSTNAMELEN], u_int16_t type,
+    u_int16_t class)
+{
+	struct rrset rrs;
+	
+	bzero(&rrs, sizeof(rrs));
+	rrs.type  = type;
+	rrs.class = class;
+	if (strlcpy(rrs.dname, name, sizeof(rrs.dname)) >= sizeof(rrs.dname)) {
+		errno = ENAMETOOLONG;
+		return (-1);
+	}
+	if (ibuf_send_imsg(&m->ibuf, IMSG_CTL_LOOKUP,
+	    &rrs, sizeof(rrs)) == -1)
+		return (-1); /* XXX: set errno */
+	
+	return (0);
+}
+
+int
+mdns_browse_add(struct mdns *m, const char *app, const char *proto)
+{
+	return (mdns_browse_adddel(m, app, proto, IMSG_CTL_BROWSE_ADD));
+}
+
+int
+mdns_browse_del(struct mdns *m, const char *app, const char *proto)
+{
+	return (mdns_browse_adddel(m, app, proto, IMSG_CTL_BROWSE_DEL));
+}
+
+static int
+mdns_browse_adddel(struct mdns *m, const char *app, const char *proto,
+    u_int msgtype)
+{
+	struct rrset mlkup;
+
+	if (app != NULL && strlen(app) > MAXHOSTNAMELEN) {
+		errno = ENAMETOOLONG;
+		return (-1);
+	}
+
+	bzero(&mlkup, sizeof(mlkup));
+
+	/* browsing for service types */
+	if (app == NULL && proto == NULL)
+		(void)strlcpy(mlkup.dname, "_services._dns-sd._udp.local",
+		    sizeof(mlkup.dname));
+	else if (snprintf(mlkup.dname, sizeof(mlkup.dname),
+	    "_%s._%s.local", app, proto) >= (int) sizeof(mlkup.dname)) {
+		errno = ENAMETOOLONG;
+		return (-1);
+	}
+	mlkup.type  = T_PTR;
+	mlkup.class = C_IN;
+	
+	if (ibuf_send_imsg(&m->ibuf, msgtype,
+	    &mlkup, sizeof(mlkup)) == -1)
+		return (-1); /* XXX: set errno */
+
+	return (0);
+}
+
+int
+mdns_resolve(struct mdns *m, const char *name, const char *app,
+    const char *proto)
+{
+	char buf[MAXHOSTNAMELEN];
+	
+	if (strcmp(proto, "tcp") != 0 && strcmp(proto, "udp") != 0) {
+		errno = EINVAL;
+		return (-1);
+	}
+	
+	if (snprintf(buf, sizeof(buf), "%s._%s._%s.local",
+	    name, app, proto) >= (int) sizeof(buf)) {
+		errno = ENAMETOOLONG;
+		return (-1);
+	}
+	
+	buf[sizeof(buf) - 1] = '\0';
+
+	if (ibuf_send_imsg(&m->ibuf, IMSG_CTL_RESOLVE,
+	    buf, sizeof(buf)) == -1)
+		return (-1); /* XXX: set errno */
+
+	return (0);
+}
+
+int
+mdns_group_add(struct mdns *m, const char *group)
+{
+	char msg[MAXHOSTNAMELEN];
+
+	bzero(msg, sizeof(msg));
+	if (strlcpy(msg, group, sizeof(msg))
+	    >= sizeof(msg))
+		return (-1);
+	if (ibuf_send_imsg(&m->ibuf, IMSG_CTL_GROUP_ADD,
+	    msg, sizeof(msg)) == -1)
+		return (-1);
+
+	return (0);
+}
+
+int
+mdns_group_reset(struct mdns *m, const char *group)
+{
+	char msg[MAXHOSTNAMELEN];
+
+	bzero(msg, sizeof(msg));
+	if (strlcpy(msg, group, sizeof(msg))
+	    >= sizeof(msg))
+		return (-1);
+	if (ibuf_send_imsg(&m->ibuf, IMSG_CTL_GROUP_RESET,
+	    msg, sizeof(msg)) == -1)
+		return (-1);
+
+	return (0);
+}
+
+int
+mdns_group_add_service(struct mdns *m, const char *group,
+    struct mdns_service *ms)
+{
+	if (strcmp(group, ms->name) != 0)
+		return (-1);
+	if (ibuf_send_imsg(&m->ibuf, IMSG_CTL_GROUP_ADD_SERVICE,
+	    ms, sizeof(*ms)) == -1)
+		return (-1);
+	
+	return (0);
+}
+
+int
+mdns_group_commit(struct mdns *m, const char *group)
+{
+	char msg[MAXHOSTNAMELEN];
+
+	if (strlcpy(msg, group, sizeof(msg))
+	    >= sizeof(msg))
+		return (-1);
+	if (ibuf_send_imsg(&m->ibuf, IMSG_CTL_GROUP_COMMIT,
+	    msg, sizeof(msg)) == -1)
+		return (-1);
+
+	return (0);
+}
+
+int
+mdns_service_init(struct mdns_service *ms, const char *name, const char *app,
+    const char *proto, u_int16_t port, const char *txt, const char *target,
+    struct in_addr *addr)
+{
+	bzero(ms, sizeof(*ms));
+	
+	if (strcmp(proto, "tcp") != 0 && strcmp(proto, "udp") != 0)
+		return (-1);
+	if (strlcpy(ms->name, name, sizeof(ms->name)) >= sizeof(ms->name))
+		return (-1);
+	if (strlcpy(ms->app, app, sizeof(ms->app)) >= sizeof(ms->app))
+		return (-1);
+	if (strlcpy(ms->proto, proto, sizeof(ms->proto)) >= sizeof(ms->proto))
+		return (-1);
+	ms->port = port;
+	if (strlcpy(ms->txt, txt, sizeof(ms->txt)) >= sizeof(ms->txt))
+		return (-1);
+	if (target != NULL)
+		if (strlcpy(ms->target, target, sizeof(ms->target)) >= sizeof(ms->target))
+			return (-1);
+	if (addr != NULL)
+		ms->addr = *addr;
+
+	return (0);
+}
+
+ssize_t
+mdns_read(struct mdns *m)
+{
+	int			ev;
+	size_t			r;
+	ssize_t			n;
+	struct imsg		imsg;
+	struct rr		rr;
+	struct mdns_service	ms;
+	char			groupname[MAXHOSTNAMELEN];
+
+	n = imsg_read(&m->ibuf);
+
+	if (n == -1 || n == 0)
+		return (n);
+
+	/* TODO call imsgctl_to_event() */
+	while ((r = imsg_get(&m->ibuf, &imsg)) > 0) {
+		switch (imsg.hdr.type) {
+		case IMSG_CTL_LOOKUP: /* FALLTHROUGH */
+		case IMSG_CTL_LOOKUP_FAILURE:
+			if ((imsg.hdr.len - IMSG_HEADER_SIZE) != sizeof(rr))
+				return (-1);
+			ev = imsg.hdr.type == IMSG_CTL_LOOKUP  ?
+			    MDNS_LOOKUP_SUCCESS : MDNS_LOOKUP_FAILURE;
+			memcpy(&rr, imsg.data, sizeof(rr));
+			r = mdns_handle_lookup(m, &rr, ev);
+			break;
+		case IMSG_CTL_BROWSE_ADD:
+		case IMSG_CTL_BROWSE_DEL:
+			if ((imsg.hdr.len - IMSG_HEADER_SIZE) != sizeof(rr))
+				return (-1);
+			ev = imsg.hdr.type == IMSG_CTL_BROWSE_ADD  ?
+			    MDNS_SERVICE_UP : MDNS_SERVICE_DOWN;
+			memcpy(&rr, imsg.data, sizeof(rr));
+			r = mdns_handle_browse(m, &rr, ev);
+			break;
+		case IMSG_CTL_RESOLVE:
+		case IMSG_CTL_RESOLVE_FAILURE:
+			if ((imsg.hdr.len - IMSG_HEADER_SIZE) != sizeof(ms))
+				return (-1);
+			ev = imsg.hdr.type == IMSG_CTL_RESOLVE  ?
+			    MDNS_RESOLVE_SUCCESS : MDNS_RESOLVE_FAILURE;
+			memcpy(&ms, imsg.data, sizeof(ms));
+			r = mdns_handle_resolve(m, &ms, ev);
+			break;
+		case IMSG_CTL_GROUP_ADD:
+		case IMSG_CTL_GROUP_RESET:
+		case IMSG_CTL_GROUP_ADD_SERVICE:
+		case IMSG_CTL_GROUP_COMMIT:
+		case IMSG_CTL_GROUP_ERR_COLLISION:
+		case IMSG_CTL_GROUP_ERR_NOT_FOUND:
+		case IMSG_CTL_GROUP_ERR_DOUBLE_ADD:
+		case IMSG_CTL_GROUP_PROBING:
+		case IMSG_CTL_GROUP_ANNOUNCING:
+		case IMSG_CTL_GROUP_PUBLISHED:
+			if ((imsg.hdr.len - IMSG_HEADER_SIZE) !=
+			    sizeof(groupname))
+				return (-1);
+			if ((ev = imsgctl_to_event(imsg.hdr.type)) == -1)
+				return (-1);
+			memcpy(groupname, imsg.data, sizeof(groupname));
+			r = mdns_handle_group(m, groupname, ev);
+			break;
+		default:
+			/* TODO remove this once in the wild */
+			warnx("Unknown imsg type %d", imsg.hdr.type);
+			return (-1);
+		}
+		
+		imsg_free(&imsg);
+	}
+
+	return (n);
+}
+
+static int
+mdns_handle_lookup(struct mdns *m, struct rr *rr, int ev)
+{
+	struct hinfo *h;
+	switch (rr->rrs.type) {
+	case T_A:
+		if (m->lhk_A == NULL)
+			return (0);
+		m->lhk_A(m, ev, rr->rrs.dname, rr->rdata.A);
+		break;
+	case T_PTR:
+		if (m->lhk_PTR == NULL)
+			return (0);
+		m->lhk_PTR(m, ev, rr->rrs.dname, rr->rdata.PTR);
+		break;
+	case T_HINFO:
+		if (m->lhk_HINFO == NULL)
+			return (0);
+		h = &rr->rdata.HINFO;
+		m->lhk_HINFO(m, ev, rr->rrs.dname, h->cpu, h->os);
+		break;
+	default:
+		return (-1);
+	}
+
+	return (0);
+}
+
+static int
+mdns_handle_browse(struct mdns *m, struct rr *rr, int ev)
+{
+	char	name[MAXHOSTNAMELEN];
+	char	app[MAXLABELLEN];
+	char	proto[MAXPROTOLEN];
+	int	hasname;
+	
+	if (rr->rrs.type != T_PTR)
+		return (-1);
+	
+	if (m->bhk == NULL)
+		return (0);
+	
+	if (splitdname(rr->rdata.PTR, name, app, proto, &hasname) == -1)
+		return (-1);
+
+	if (hasname)
+		m->bhk(m, ev, name, app, proto);
+	else
+		m->bhk(m, ev, NULL, app, proto);
+
+	return (0);
+}
+
+static int
+mdns_handle_resolve(struct mdns *m, struct mdns_service *ms, int ev)
+{
+	int hasname;
+
+	if (m->rhk == NULL)
+		return (0);
+	if (splitdname(ms->name, ms->name, ms->app, ms->proto, &hasname) == -1)
+		return (-1);
+	if (hasname == 0)
+		return (-1);
+
+	m->rhk(m, ev, ms);
+	
+	return (0);
+}
+
+static int
+mdns_handle_group(struct mdns *m, char groupname[MAXHOSTNAMELEN], int ev)
+{
+	if (m->ghk == NULL)
+		return (0);
+	
+	m->ghk(m, ev, groupname);
+	
+	return (0);
+}
+
+static int
+mdns_connect(void)
+{
+	struct sockaddr_un	sun;
+	int			sockfd;
+
+	bzero(&sun, sizeof(sun));
+	if ((sockfd = socket(AF_UNIX, SOCK_STREAM, 0)) == -1)
+		return (-1);
+	sun.sun_family = AF_UNIX;
+	(void)strlcpy(sun.sun_path, MDNSD_SOCKET,
+	    sizeof(sun.sun_path));
+	if (connect(sockfd, (struct sockaddr *)&sun, sizeof(sun)) == -1) {
+		if (errno == ENOENT)
+			errno = ECONNREFUSED;
+		close(sockfd);
+		return (-1);
+	}
+
+	return (sockfd);
+}
+
+static int
+ibuf_send_imsg(struct imsgbuf *ibuf, u_int32_t type,
+    void *data, u_int16_t datalen)
+{
+	struct ibuf	*wbuf;
+
+	if ((wbuf = imsg_create(ibuf, type, 0,
+	    0, datalen)) == NULL)
+		return (-1);
+
+	if (imsg_add(wbuf, data, datalen) == -1)
+		return (-1);
+
+	wbuf->fd = -1;
+
+	imsg_close(ibuf, wbuf);
+
+	if (msgbuf_write(&ibuf->w) == -1)
+		return (-1);
+
+	return (0);
+}
+
+/* XXX: Too ugly, code me again with love */
+static int
+splitdname(char fname[MAXHOSTNAMELEN], char sname[MAXHOSTNAMELEN],
+    char app[MAXLABEL], char proto[MAXPROTOLEN], int *hasname)
+{
+	char namecp[MAXHOSTNAMELEN];
+	char *p, *start;
+
+	*hasname = 1;
+/*	 ubuntu810desktop [00:0c:29:4d:22:ce]._workstation._tcp.local */
+/*	_workstation._tcp.local */
+	/* work on a copy */
+	(void)strlcpy(namecp, fname, sizeof(namecp));
+
+	/* check if we have a name, or only an application protocol */
+	if ((p = strstr(namecp, "._")) != NULL) {
+		p += 2;
+		if ((p = strstr(p, "._")) == NULL)
+			*hasname = 0;
+	}
+
+	p = start = namecp;
+
+	/* if we have a name, copy */
+	if (*hasname == 1 && sname != NULL) {
+		if ((p = strstr(start, "._")) == NULL)
+			return (-1);
+		*p++ = 0;
+		p++;
+		(void)strlcpy(sname, start, MAXHOSTNAMELEN);
+		start = p;
+	}
+	else
+		start++;
+
+	if ((p = strstr(start, "._")) == NULL)
+		return (-1);
+	*p++ = 0;
+	p++;
+	(void)strlcpy(app, start, MAXLABEL);
+	start = p;
+
+	if ((p = strstr(start, ".")) == NULL)
+		return (-1);
+	*p++ = 0;
+	(void)strlcpy(proto, start, MAXPROTOLEN);
+
+	return (0);
+}
+
+static int
+imsgctl_to_event(int msgtype)
+{
+	switch (msgtype) {
+	case IMSG_CTL_GROUP_ERR_COLLISION:
+		return
+		    (MDNS_GROUP_ERR_COLLISION);
+		break;
+	case IMSG_CTL_GROUP_ERR_NOT_FOUND:
+		return
+		    (MDNS_GROUP_ERR_NOT_FOUND);
+		break;
+	case IMSG_CTL_GROUP_ERR_DOUBLE_ADD:
+		return
+		    (MDNS_GROUP_ERR_DOUBLE_ADD);
+		break;
+	case IMSG_CTL_GROUP_PROBING:
+		return
+		    (MDNS_GROUP_PROBING);
+		break;
+	case IMSG_CTL_GROUP_ANNOUNCING:
+		return
+		    (MDNS_GROUP_ANNOUNCING);
+		break;
+	case IMSG_CTL_GROUP_PUBLISHED:
+		return
+		    (MDNS_GROUP_PUBLISHED);
+		break;
+	default:
+		/* TODO remove this once in the wild */
+		warnx("imsgctl_to_event: Unknown imsgctl %d",
+		    msgtype);
+	}
+	/* NOTREACHED */
+	return (-1);
+}
+
+void
+reversstr(char str[MAXHOSTNAMELEN], struct in_addr *addr)
+{
+	const u_char *uaddr = (const u_char *)addr;
+
+	(void) snprintf(str, MAXHOSTNAMELEN, "%u.%u.%u.%u.in-addr.arpa",
+	    (uaddr[3] & 0xff), (uaddr[2] & 0xff),
+	    (uaddr[1] & 0xff), (uaddr[0] & 0xff));
+}
+


### PR DESCRIPTION
This is an ongoing project with only a few hours of work in it, but I thought I'd put it out there as soon as possible for comment.  **mdnshosts** is basically a channel between `mdsnctl browse -r` and */etc/hosts*.  It's essentially a revamped `mdnsctl`.

The daemon starts up, creates worker children, then the main process continues to listen on the `mdnsd` socket.  When entries come online or go offline, this main process sends this information to a writer process.  The writer process maintains a database of entry name to host to IP mappings.  When the database changes, it flushes the text to a file in [hosts(5)](http://man.openbsd.org/hosts.5) format and notifies the replacer child.  The replacer child swaps the temporary file into the real */etc/hosts* file atomically.

All of the processes have [pledge(2)](http://man.openbsd.org/pledge.2) and [chroot(2)](http://man.openbsd.org/chroot.2).  However, the security can be greatly increased.

On my list of things to do:

1. Tighten down pledges in the writer, possibly splitting this into another process.
2. Increase sanity checks on the hosts database.
3. Logging to syslog, not stderr.
4. Pruning out mdnsl.c (copied over from mdnsctl).
5. And so much more---I just wrote this today.

I wrote this because I was so frustrated with our network changing IP addresses all the time and needing to run `mdnsctl lookup -r` every time I used SSH or printed.