### PR TITLE
Include dir relative to the current dir

### DIFF
--- a/mdnsd/Makefile
+++ b/mdnsd/Makefile
@@ -8,7 +8,7 @@ SRCS=	log.c mdnsd.c kiface.c interface.c packet.c \
 
 MAN=	mdnsd.8
 
-CFLAGS+= -g -Wall -I${.CURDIR} -I../
+CFLAGS+= -g -Wall -I${.CURDIR} -I${.CURDIR}/../
 CFLAGS+= -Wstrict-prototypes -Wmissing-prototypes
 CFLAGS+= -Wmissing-declarations
 CFLAGS+= -Wshadow -Wpointer-arith -Wcast-qual


### PR DESCRIPTION
When using an objdir ../ is relative from the objdir, so it does
not do what you'd expect.  Adding ${.CURDIR} makes sure that it
is relative to the directory the makefile is in.