### PR TITLE
Silence complaints generated by mdnsd when legacy AirDrop is used on macOS

### DIFF
--- a/mdnsd/log.c
+++ b/mdnsd/log.c
@@ -222,6 +222,9 @@ rr_type_name(uint16_t type)
 	case T_OPT:
 		return "OPT";
 		break;		/* NOTREACHED */
+	case T_NULL:
+		return "NULL";
+		break;		/* NOTREACHED */
 	default:
 		log_debug("Unknown %d", type);
 		break;		/* NOTREACHED */

--- a/mdnsd/packet.c
+++ b/mdnsd/packet.c
@@ -1063,6 +1063,7 @@ handletype:
 		break;
 	case T_AAAA:
 	case T_NSEC:
+	case T_NULL:
 		break;
 	case T_OPT:
 		/*


### PR DESCRIPTION
These two minor changes stop mdnsd from logging errors for unknown RR types for the T_NULL (10) RR when a mac uses legacy AirDrop within range of an mdnsd's hearing.

Recognizing (and ignoring) the T_NULL RR will also allow any other RR entries in the received packet to be processed rather than aborting packet processing for an unrecognized type.