### PR TITLE
Fix mdoc(7) markup issues found with `mandoc -T lint`

### DIFF
--- a/mdnsctl/mdnsctl.8
+++ b/mdnsctl/mdnsctl.8
@@ -18,7 +18,7 @@
 .Os
 .Sh NAME
 .Nm mdnsctl
-.Nd control the Multicast Domain Server daemon
+.Nd control the Multicast DNS server daemon
 .Sh SYNOPSIS
 .Nm
 .Ar command
@@ -28,8 +28,8 @@ The
 .Nm
 program controls the
 .Xr mdnsd 8
-daemon, it can perform simples MDNS lookups, as well as browsing and publishing
-MDNS/DNS-SD services.
+daemon, it can perform simples mDNS lookups, as well as browsing and publishing
+mDNS/DNS-SD services.
 .Pp
 The following commands are available:
 .Bl -tag -width xxxxxx
@@ -55,7 +55,6 @@ SRV record (Service). Unimplemented.
 .It Cm -t
 TXT record (Text). Unimplemented.
 .El
-.Pp
 .It Cm rlookup Ar a.b.c.d
 Reverse lookup an IPv4 address in the
 .Ar a.b.c.d
@@ -120,7 +119,7 @@ form.
 .El
 .Sh FILES
 .Bl -tag -width "/var/run/mdnsctl.sockXX" -compact
-.It /var/run/mdnsctl.sock
+.It Pa /var/run/mdnsctl.sock
 .Ux Ns -domain
 socket used for communication with
 .Xr mdnsd 8 .
@@ -128,31 +127,38 @@ socket used for communication with
 .Sh EXAMPLES
 The following examples demonstrate some basic uses of
 .Nm .
-.Bd -literal
-# Lookup a host A and HINFO record
-mdnsctl lookup -ah foobar.local
-
-# Reverse lookup an address
-mdnsctl rlookup 192.168.8.32
-
-# Browse up all services in the local network
-mdnsctl browse
-
-# Browse and resolve all services
-mdnsctl browse -r
-
-# Browse and resolve all services and output in script-readable format
-mdnsctl browse -rs
-
-# Browse and resolve all the http services in the local network
-mdnsctl browse -r http tcp
-
-# Publish a simple ftp service
-mdnsctl publish myftp ftp tcp 21 "user=foobar"
-
-# Proxy publish a https service that has www.mysite.com as the target
-mdnsctl proxy mysite https tcp 443 www.mysite.com 12.3.45.6 "user=foobar"
-.Ed
+.Pp
+Lookup a host A and HINFO record
+.Pp
+.Dl # mdnsctl lookup -ah foobar.local
+.Pp
+Reverse lookup an address
+.Pp
+.Dl # mdnsctl rlookup 192.168.8.32
+.Pp
+Browse up all services in the local network
+.Pp
+.Dl # mdnsctl browse
+.Pp
+Browse and resolve all services
+.Pp
+.Dl # mdnsctl browse -r
+.Pp
+Browse and resolve all services and output in script-readable format
+.Pp
+.Dl # mdnsctl browse -rs
+.Pp
+Browse and resolve all the http services in the local network
+.Pp
+.Dl # mdnsctl browse -r http tcp
+.Pp
+Publish a simple ftp service
+.Pp
+.Dl # mdnsctl publish myftp ftp tcp 21 "user=foobar"
+.Pp
+Proxy publish a https service that has www.mysite.com as the target
+.Pp
+.Dl # mdnsctl proxy mysite https tcp 443 www.mysite.com 12.3.45.6 "user=foobar"
 .Sh SEE ALSO
 .Xr mdnsd 8
 .Sh LICENSE
@@ -163,4 +169,4 @@ The
 .Nm
 program version 0.1 was released in 13 February 2011.
 .Sh AUTHORS
-Christiano Farina Haesbaert <haesbaert@haesbaert.org>
+.An Christiano Farina Haesbaert Aq Mt haesbaert@haesbaert.org

--- a/mdnsd/mdnsd.8
+++ b/mdnsd/mdnsd.8
@@ -14,11 +14,11 @@
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
 .Dd $Mdocdate: Feb 06 2011 $
-.Dt mdnsd 8
+.Dt MDNSD 8
 .Os
 .Sh NAME
 .Nm mdnsd
-.Nd "Multicast DNS/DNS-SD daemon"
+.Nd Multicast DNS/DNS-SD daemon
 .Sh SYNOPSIS
 .Nm
 .Op Fl dvw
@@ -27,91 +27,93 @@
 .Sh DESCRIPTION
 .Nm
 is a Multicast Domain Name System
-.Pq MDNS
-daemon which acts as the host mdns querier and responder.
+.Pq mDNS
+daemon which acts as the host mDNS querier and responder.
 .Nm
-supports both raw MDNS as well as DNS-SD (Service Discovery) as described in the
-MDNS and DNS-SD drafts.
+supports both raw mDNS as well as DNS-SD (Service Discovery) as described in
+the mDNS and DNS-SD RFCs.
 .Pp
-MDNS is a way to perform DNS-like operations via multicast in the local link,
-there is no hierarchy or multiple domains as in conventional unicast DNS. MDNS
-provides a way for hosts to co-operate and maintain a cache name database which
-can then be used to resolve local host names without the need of a central DNS
-server.
+mDNS is a way to perform DNS-like operations via multicast in the local link,
+there is no hierarchy or multiple domains as in conventional unicast DNS.
+mDNS provides a way for hosts to co-operate and maintain a cache name database
+which can then be used to resolve local host names without the need of a
+central DNS server.
 .Pp
-DNS-SD is a convention on some names used in MDNS to provide hosts with Service
-Discovery capabilities.
-
+DNS-SD is a convention on some names used in mDNS to provide hosts with
+Service Discovery capabilities.
 A host can publish a service of any type, be it a HTTP server, NTP server, a
-Printer and so on, this services can then be browsed and resolved by the other
+printer and so on, this services can then be browsed and resolved by the other
 hosts in the local network.
 .Pp
-There are basically two roles in a MDNS environment, the Querier, and the
+There are basically two roles in a mDNS environment, the Querier, and the
 Responder.
-
-The Querier is the entity responsible for sending questions and MDNS
-requests in the local link, it can't be done as it is in libc, where each process
-does its own lookup, there must be something centralizing all the requests as
-there are various complications implied: cache, timers and so on.
+The Querier is the entity responsible for sending questions and mDNS requests
+in the local link, it can't be done as it is in libc, where each process does
+its own lookup, there must be something centralizing all the requests as there
+are various complications implied: cache, timers and so on.
 .Pp
 The Responder is the entity responsible for answering those queries, there
-should be only one responder per host. Both roles are performed by MDNS.
-
-MDNS operates on the All-Link-Local Multicast address 224.0.0.251 under UDP port
-5353. There are no multiple domains in MDNS as in unicast DNS, the .local domain
-name is the single MDNS domain name and it's where all the queries and answers
+should be only one responder per host.
+Both roles are performed by mDNS.
+mDNS operates on the link-local multicast address 224.0.0.251 under UDP
+port 5353.
+There are no multiple domains in mDNS as in unicast DNS, the .local domain
+name is the single mDNS domain name and it's where all the queries and answers
 take place.
 .Pp
-There are three basic types of MDNS question, in which
+There are three basic types of mDNS question, in which
 .Nm
 uses two of them.
-
-The One-Shot Query, which resembles unicast DNS, where a single question is sent
-and an answer is expected, if no answer is received it means no one can answer
-that question. This question is used for simple lookups.
+The One-Shot Query, which resembles unicast DNS, where a single question is
+sent and an answer is expected, if no answer is received it means no one can
+answer that question.
+This question is used for simple lookups.
 .Pp
 Continuous Multicast Query is a more complex way of querying, the querier will
-send the same question multiple times, doubling the interval between each time,
- multiple answers may be received, it's used as a way for monitoring the
-Resource Records of the network. This question is mainly used by network
-browsing in DNS-SD, where a question for a type of service may enumerate one or
-more instances, for example, if browsing for the HTTP servers, there may be one
-or more servers (instances).
-
+send the same question multiple times, doubling the interval between each
+time, multiple answers may be received, it's used as a way for monitoring the
+Resource Records of the network.
+This question is mainly used by network browsing in DNS-SD, where a question
+for a type of service may enumerate one or more instances, for example, if
+browsing for the HTTP servers, there may be one or more servers (instances).
 To diminish the volume of redundant answers, a feature called Known Answer
 Suppression is present, in which the querier when performing a Continuous
-Multicast Query places all the previous known answers in the additional section
-of the MDNS packet, thus, any answer that would be given which is already in the
-additional section, is suppressed.
+Multicast Query places all the previous known answers in the additional
+section of the mDNS packet, thus, any answer that would be given which is
+already in the additional section, is suppressed.
 .Pp
 There are two type of Resource Records, Unique and Shared.
 .Pp
 Unique records are the ones which there may be only one answer for it in the
 local name, the A, PTR and HINFO under the hostname.local name are examples of
-Unique records, it would be strange if two hosts would answer an address for the
-same foobar.local. All Unique records must be Probed to verify its uniqueness,
-if a conflict is found, another name must be chosen (Unimplemented).
+Unique records, it would be strange if two hosts would answer an address for
+the same foobar.local.
+All Unique records must be Probed to verify its uniqueness, if a conflict is
+found, another name must be chosen (Unimplemented).
 .Pp
 A Shared record is used for PTR records in DNS-SD, a host may have as many
 answers as necessary for a shared record, it's used only in network browsing,
 where there may be multiple instances of the same service.
-.PP
-To access the MDNS services, a libmdns library will be provided in the near
+.Pp
+To access the mDNS services, a libmdns library will be provided in the near
 future, programs will then, be able to link with libmdns and publish its own
-services though MDNS. By now, only mdnsctl(8) is provided which is a command
-line interface to the daemon in the same fashion as ripctl(8) and ospfctl(8).
+services though mDNS.
+By now, only mdnsctl(8) is provided which is a command line interface to the
+daemon in the same fashion as ripctl(8) and ospfctl(8).
 .Pp
 When
 .Nm
-starts up, it probes for its hostname (fetched from /etc/myname), if 
-there isn't a conflict, it publishes an A and a PTR record for itself,
-both records will be under the .local domain, which is the MDNS single domain
-name. All the other domain names in /etc/myname will be stripped, therefore
-foo.bar.midearth becomes foo.local, which can be resolved through MDNS. If a
-conflict is found, then, there is another foo.local in the network and conflict
-resolution takes place.
+starts up, it probes for its hostname (fetched from /etc/myname), if there
+isn't a conflict, it publishes an A and a PTR record for itself, both records
+will be under the .local domain, which is the mDNS single domain name.
+All the other domain names in /etc/myname will be stripped, therefore
+foo.bar.midearth becomes foo.local, which can be resolved through mDNS.
+If a conflict is found, then, there is another foo.local in the network and
+conflict resolution takes place.
 .Pp
-If -w was not specified,
+If
+Fl w
+was not specified,
 .Nm
 will also publish a Workstation service, this service has no data itself, it's
 used to state that the host is up, it can be used for example, to browse every
@@ -120,13 +122,13 @@ powered host on the local network.
 .Nm
 supports multiple interfaces, the interfaces used must be specified as the
 arguments.
-.PP
+.Pp
 .Nm
 must be started as root and upon start up it will drop privileges, change it's
-euid/egid to _mdnsd and chroot. Therefore make sure you have user and group
-_mdnsd created.
+euid/egid to _mdnsd and chroot.
+Therefore make sure you have user and group _mdnsd created.
 .Pp
-MDNS operations can be done with the
+mDNS operations can be done with the
 .Xr mdnsctl 8
 utility.
 .Pp
@@ -153,23 +155,27 @@ socket used for communication with
 .Sh SEE ALSO
 .Xr mdnsctl 8
 .Rs
-.%R http://files.multicastdns.org/draft-cheshire-dnsext-multicastdns.txt
-.%T "MDNS Draft"
-.%D July 2010
+.%A S. Cheshire
+.%A M. Krochmal
+.%D February 2013
+.%R RFC 6762
+.%T Multicast DNS
 .Re
 .Rs
-.%R http://files.dns-sd.org/draft-cheshire-dnsext-dns-sd.txt 
-.%T "DNS-SD Draft"
-.%D January 2011
+.%A S. Cheshire
+.%A M. Krochmal
+.%D February 2013
+.%R RFC 6763
+.%T DNS-Based Service Discovery
 .Re
 .Sh LICENSE
 .Nm
-is released under the ISC license.x
+is released under the ISC license.
 .Sh HISTORY
 The
 .Nm
 program version 0.1 was released in 13 February 2011.
 .Sh AUTHORS
-Christiano Farina Haesbaert <haesbaert@haesbaert.org>
+.An Christiano Farina Haesbaert Aq Mt haesbaert@haesbaert.org
 .Sh BUGS
 No proper error return in mdnsl.c.


### PR DESCRIPTION
While there:
- replace links to drafts with references to published RFCs
- fix capitalisation on mDNS as used throughout the RFCs
- reformat the `EXAMPLES` section using style found in existing
  OpenBSD manual pages