### PR TITLE
Fix RR leaks from cache_process()

### DIFF
--- a/mdnsd/mdns.c
+++ b/mdnsd/mdns.c
@@ -169,6 +169,7 @@ cache_process(struct rr *rr)
 				log_warnx("cache_process: conflict for %s",
 				    rrs_str(&rr->rrs));
 				conflict_resolve_by_rr(rr_aux);
+				free(rr);
 				return (-1);
 			}
 		}

--- a/mdnsd/mdns.c
+++ b/mdnsd/mdns.c
@@ -155,8 +155,10 @@ cache_process(struct rr *rr)
 					/* TODO Cancel possible deletion */
 					log_info("cache_process: recover %s",
 					    rrs_str(&rr->rrs));
+					free(rr);
 					return (0);
 				}
+				free(rr);
 				return (0);
 			}
 			/*
@@ -178,6 +180,7 @@ cache_process(struct rr *rr)
 					log_info("cache_process: goodbye %s",
 					    rrs_str(&rr->rrs));
 					cache_delete(rr_aux);
+					free(rr);
 					return (0);
 				}
 				/* Cache refresh */
@@ -186,14 +189,16 @@ cache_process(struct rr *rr)
 				rr_aux->ttl = rr->ttl;
 				rr_aux->revision = 0;
 				cache_schedrev(rr_aux);
-
+				free(rr);
 				return (0);
 			}
 		}
 	}
 	/* Got a goodbye for a record we don't have */
-	if (rr->ttl == 0)
+	if (rr->ttl == 0) {
+		free(rr);
 		return (0);
+	}
 
 	return (cache_insert(rr));
 }


### PR DESCRIPTION
Free RR entries that are leaked by cache_process when they are not incorporated
into the cache.

Closes haesbaert/mdnsd#37