### PR TITLE
mdnsd: dont overwrite malloc_options

### DIFF
--- a/mdnsd/mdnsd.c
+++ b/mdnsd/mdnsd.c
@@ -307,7 +307,6 @@ main(int argc, char *argv[])
 		switch (ch) {
 		case 'd':
 			debug = 1;
-			malloc_options = "CFGJ";
 			break;
 		default:
 			break;


### PR DESCRIPTION
malloc_options is declared 'const char * const', and trying to overwrite it in main results in a SIGSEGV if the -d flag is passed.

the daemon should instead be run with MALLOC_OPTIONS="CFGJ" in the environment.

the bug is clear with gdb from packages:

```
fugu$ doas env LD_LIBRARY_PATH="$(pwd)/libmdns/" egdb -batch -ex 'r -d' -ex 'bt' ./mdnsd/mdnsd

Program received signal SIGSEGV, Segmentation fault.
0x0000080b8acd3def in main (argc=2, argv=0x7d508912d438) at mdnsd.c:312
312                             malloc_options = "CFGJ";
#0  0x0000080b8acd3def in main (argc=2, argv=0x7d508912d438) at mdnsd.c:312
```