### PR TITLE
patch splat from ports

### DIFF
--- a/libmdns/mdnsl.c
+++ b/libmdns/mdnsl.c
@@ -59,7 +59,8 @@ mdns_open(struct mdns *m)
 	bzero(m, sizeof(*m));
 	if ((sockfd = mdns_connect()) == -1)
 		return (-1);
-	imsg_init(&m->ibuf, sockfd);
+	if (imsgbuf_init(&m->ibuf, sockfd) == -1)
+		return (-1);
 	
 	return (sockfd);
 }
@@ -67,7 +68,7 @@ mdns_open(struct mdns *m)
 void
 mdns_close(struct mdns *m)
 {
-	imsg_clear(&m->ibuf);
+	imsgbuf_clear(&m->ibuf);
 }
 
 void
@@ -329,7 +330,7 @@ mdns_read(struct mdns *m)
 	struct mdns_service	ms;
 	char			groupname[MAXHOSTNAMELEN];
 
-	n = imsg_read(&m->ibuf);
+	n = imsgbuf_read(&m->ibuf);
 
 	if (n == -1 || n == 0)
 		return (n);
@@ -514,7 +515,7 @@ ibuf_send_imsg(struct imsgbuf *ibuf, u_int32_t type,
 
 	imsg_close(ibuf, wbuf);
 
-	if (msgbuf_write(&ibuf->w) == -1)
+	if (imsgbuf_write(ibuf) == -1)
 		return (-1);
 
 	return (0);

--- a/mdnsctl/Makefile
+++ b/mdnsctl/Makefile
@@ -12,11 +12,7 @@ CFLAGS+= -Wshadow -Wpointer-arith -Wcast-qual
 CFLAGS+= -Wsign-compare
 CFLAGS+= -I${.CURDIR} -I${.CURDIR}/../mdnsd
 
-.if exists(${.CURDIR}/../libmdns/${__objdir})
-LDADD+= -L${.CURDIR}/../libmdns/${__objdir} -lmdns
-.else
 LDADD+= -L${.CURDIR}/../libmdns -lmdns
-.endif
 LDADD+= -lutil
 DPADD+=  ${LIBUTIL}
 

--- a/mdnsd/Makefile
+++ b/mdnsd/Makefile
@@ -14,11 +14,7 @@ CFLAGS+= -Wmissing-declarations
 CFLAGS+= -Wshadow -Wpointer-arith -Wcast-qual
 CFLAGS+= -Wsign-compare
 
-.if exists(${.CURDIR}/../libmdns/${__objdir})
-LDADD+= -L${.CURDIR}/../libmdns/${__objdir} -lmdns
-.else
 LDADD+= -L${.CURDIR}/../libmdns -lmdns
-.endif
 LDADD+= -levent -lutil
 DPADD+= ${LIBEVENT} ${LIBUTIL}
 

--- a/mdnsd/control.c
+++ b/mdnsd/control.c
@@ -53,6 +53,8 @@ void		 control_group_add_service(struct ctl_conn *, struct imsg *);
 
 extern struct mdnsd_conf *conf;
 
+struct control_state control_state;
+
 void
 control_lookup(struct ctl_conn *c, struct imsg *imsg)
 {
@@ -566,8 +568,13 @@ control_accept(int listenfd, short event, void *bula)
 		return;
 	}
 
+	if (imsgbuf_init(&c->iev.ibuf, connfd) == -1) {
+		log_warn("control_accept");
+		close(connfd);
+		free(c);
+		return;
+	}
 	LIST_INIT(&c->qlist);
-	imsg_init(&c->iev.ibuf, connfd);
 	c->iev.handler = control_dispatch_imsg;
 	c->iev.events = EV_READ;
 	event_set(&c->iev.ev, c->iev.ibuf.fd, c->iev.events,
@@ -612,7 +619,7 @@ control_close(int fd)
 		log_warn("control_close: fd %d: not found", fd);
 		return;
 	}
-	msgbuf_clear(&c->iev.ibuf.w);
+	imsgbuf_clear(&c->iev.ibuf);
 	TAILQ_REMOVE(&ctl_conns, c, entry);
 
 	event_del(&c->iev.ev);
@@ -644,13 +651,13 @@ control_dispatch_imsg(int fd, short event, void *bula)
 	}
 
 	if (event & EV_READ) {
-		if ((n = imsg_read(&c->iev.ibuf)) == -1 || n == 0) {
+		if ((n = imsgbuf_read(&c->iev.ibuf)) == -1 || n == 0) {
 			control_close(fd);
 			return;
 		}
 	}
 	if (event & EV_WRITE) {
-		if (msgbuf_write(&c->iev.ibuf.w) == -1) {
+		if (imsgbuf_write(&c->iev.ibuf) == -1) {
 			control_close(fd);
 			return;
 		}

--- a/mdnsd/control.h
+++ b/mdnsd/control.h
@@ -26,10 +26,12 @@
 
 #include "mdnsd.h"
 
-struct {
+struct control_state {
 	struct event	ev;
 	int		fd;
-} control_state;
+};
+
+extern struct control_state control_state;
 
 enum blockmodes {
 	BM_NORMAL,

--- a/mdnsd/control.h
+++ b/mdnsd/control.h
@@ -31,8 +31,6 @@ struct control_state {
 	int		fd;
 };
 
-extern struct control_state control_state;
-
 enum blockmodes {
 	BM_NORMAL,
 	BM_NONBLOCK

--- a/mdnsd/mdns.c
+++ b/mdnsd/mdns.c
@@ -45,6 +45,9 @@ extern struct mdnsd_conf	*conf;
 struct question_tree		 question_tree;
 struct cache_tree		 cache_tree;
 
+pg_q pg_queue;
+pge_q pge_queue;
+
 /*
  * RR cache
  */

--- a/mdnsd/mdns.c
+++ b/mdnsd/mdns.c
@@ -45,8 +45,8 @@ extern struct mdnsd_conf	*conf;
 struct question_tree		 question_tree;
 struct cache_tree		 cache_tree;
 
-pg_q pg_queue;
-pge_q pge_queue;
+struct pg_q pg_queue;
+struct pge_q pge_queue;
 
 /*
  * RR cache

--- a/mdnsd/mdnsd.c
+++ b/mdnsd/mdnsd.c
@@ -51,7 +51,7 @@ void			 fetchmyname(char [MAXHOSTNAMELEN]);
 void			 fetchhinfo(struct hinfo *);
 struct reflect_rule	*parse_reflect_rule(char *);
 
-ctl_conns_t	ctl_conns;
+struct ctl_conns	ctl_conns;
 
 struct mdnsd_conf	*conf = NULL;
 extern char		*malloc_options;

--- a/mdnsd/mdnsd.c
+++ b/mdnsd/mdnsd.c
@@ -51,6 +51,8 @@ void			 fetchmyname(char [MAXHOSTNAMELEN]);
 void			 fetchhinfo(struct hinfo *);
 struct reflect_rule	*parse_reflect_rule(char *);
 
+ctl_conns_t	ctl_conns;
+
 struct mdnsd_conf	*conf = NULL;
 extern char		*malloc_options;
 
@@ -454,12 +456,12 @@ void
 imsg_event_add(struct imsgev *iev)
 {
 	if (iev->handler == NULL) {
-		imsg_flush(&iev->ibuf);
+		imsgbuf_flush(&iev->ibuf);
 		return;
 	}
 
 	iev->events = EV_READ;
-	if (iev->ibuf.w.queued)
+	if (imsgbuf_queuelen(&iev->ibuf) > 0)
 		iev->events |= EV_WRITE;
 
 	event_del(&iev->ev);

--- a/mdnsd/mdnsd.h
+++ b/mdnsd/mdnsd.h
@@ -223,11 +223,11 @@ struct pge {
 };
 
 /* Publish Group Queue, should hold all publishing groups */
-typedef TAILQ_HEAD(, pg) pg_q;
-extern pg_q pg_queue;
+TAILQ_HEAD(pg_q, pg);
+extern struct pg_q pg_queue;
 /* Publish Group Entry Queue, should hold all publishing group entries */
-typedef TAILQ_HEAD(, pge) pge_q;
-extern pge_q pge_queue;
+TAILQ_HEAD(pge_q, pge);
+extern struct pge_q pge_queue;
 
 struct kif {
 	char			ifname[IF_NAMESIZE];
@@ -427,8 +427,8 @@ int		 rr_send_an(struct rr *);
 void		 conflict_resolve_by_rr(struct rr *);
 
 /* control.c */
-typedef TAILQ_HEAD(ctl_conns, ctl_conn) ctl_conns_t;
-extern ctl_conns_t ctl_conns;
+TAILQ_HEAD(ctl_conns, ctl_conn);
+extern struct ctl_conns ctl_conns;
 int     control_send_rr(struct ctl_conn *, struct rr *, int);
 int	control_send_ms(struct ctl_conn *, struct mdns_service *, int);
 int     control_try_answer_ms(struct ctl_conn *, char[MAXHOSTNAMELEN]);

--- a/mdnsd/mdnsd.h
+++ b/mdnsd/mdnsd.h
@@ -223,9 +223,11 @@ struct pge {
 };
 
 /* Publish Group Queue, should hold all publishing groups */
-TAILQ_HEAD(, pg)  pg_queue;
+typedef TAILQ_HEAD(, pg) pg_q;
+extern pg_q pg_queue;
 /* Publish Group Entry Queue, should hold all publishing group entries */
-TAILQ_HEAD(, pge) pge_queue;
+typedef TAILQ_HEAD(, pge) pge_q;
+extern pge_q pge_queue;
 
 struct kif {
 	char			ifname[IF_NAMESIZE];
@@ -425,7 +427,8 @@ int		 rr_send_an(struct rr *);
 void		 conflict_resolve_by_rr(struct rr *);
 
 /* control.c */
-TAILQ_HEAD(ctl_conns, ctl_conn) ctl_conns;
+typedef TAILQ_HEAD(ctl_conns, ctl_conn) ctl_conns_t;
+extern ctl_conns_t ctl_conns;
 int     control_send_rr(struct ctl_conn *, struct rr *, int);
 int	control_send_ms(struct ctl_conn *, struct mdns_service *, int);
 int     control_try_answer_ms(struct ctl_conn *, char[MAXHOSTNAMELEN]);


### PR DESCRIPTION
this applies all patches from openbsd ports. the differences are mostly imsg api fixes and type declaration changes.