### PR TITLE
mdnsd: remove global malloc_options declaration

### DIFF
--- a/mdnsd/mdnsd.c
+++ b/mdnsd/mdnsd.c
@@ -52,7 +52,6 @@ void			 fetchhinfo(struct hinfo *);
 struct reflect_rule	*parse_reflect_rule(char *);
 
 struct mdnsd_conf	*conf = NULL;
-extern char		*malloc_options;
 
 __dead void
 usage(void)


### PR DESCRIPTION
fixup for 5d0bdc6 (mdnsd: dont overwrite malloc_options, 2026-01-28) where i forgot to remove the global malloc_options symbol declaration.