### PR TITLE
mdnsd: fix reflector rule acceptance

### DIFF
--- a/mdnsd/mdnsd.c
+++ b/mdnsd/mdnsd.c
@@ -268,6 +268,7 @@ parse_reflect_rule(char *s)
 
 	if ((rule = calloc(1, sizeof(*rule))) == NULL)
 		fatal("calloc");
+	rule->accept = accept;
 	if (snprintf(rule->sname, sizeof(rule->sname), "%s.local", sname)
 	    >= MAXHOSTNAMELEN)
 		return (NULL);


### PR DESCRIPTION
c1e71dd (Initial attempt at a reflector., 2021-01-11) added reflector rule parsing, but didn't initialize the rule with the parsed accept/deny, leaving them to always be deny (i think).

assign the parsed value to the rule.

fixes the warning:

	mdnsd.c:235:13: warning: variable 'accept' set but not used [-Wunused-but-set-variable]
	  235 |         int htype, accept;
	      |                    ^