### PR TITLE
mdnsd: fix segfault logging unmatched continuation packets

### DIFF
--- a/mdnsd/packet.c
+++ b/mdnsd/packet.c
@@ -331,7 +331,7 @@ recv_packet(int fd, short event, void *bula)
 			pkt = match;
 		}
 		else
-			log_warnx("Got a continuation packet from %s:%s "
+			log_warnx("Got a continuation packet from %s:%u "
 			    "but no match", inet_ntoa(pkt->ipsrc.sin_addr),
 			    ntohs(pkt->ipsrc.sin_port));
 	}


### PR DESCRIPTION
The "no match" branch in recv_packet() formats the source port with %s, but ntohs() returns a uint16_t, so vfprintf walks the integer as a char* and crashes in strlen. Switched it to %u, matching the two other sites that log inet_ntoa()/ntohs(sin_port) at packet.c:376 and mdnsd.c:188. log_warnx() has no printf format attribute, which is why the mismatch was never flagged at build time. Fixes #51.